### PR TITLE
Add Hardhat test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "hardhat test"
   },
   "dependencies": {
     "@reown/appkit": "1.7.8",

--- a/test/multisender.ts
+++ b/test/multisender.ts
@@ -1,0 +1,32 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+
+describe("Multisender", function () {
+  const amounts = [ethers.parseEther("1"), ethers.parseEther("2")];
+
+  it("emits an event after dispersing ether", async function () {
+    const [owner, addr1, addr2] = await ethers.getSigners();
+    const Multisender = await ethers.getContractFactory("Multisender");
+    const multisender = await Multisender.deploy();
+    const recipients = [addr1.address, addr2.address];
+    const total = amounts[0] + amounts[1];
+
+    await expect(
+      multisender.disperseEther(recipients, amounts, { value: total })
+    )
+      .to.emit(multisender, "EtherDispersed")
+      .withArgs(owner.address, total, recipients.length);
+  });
+
+  it("transfers the specified amounts", async function () {
+    const [_, addr1, addr2] = await ethers.getSigners();
+    const Multisender = await ethers.getContractFactory("Multisender");
+    const multisender = await Multisender.deploy();
+    const recipients = [addr1.address, addr2.address];
+    const total = amounts[0] + amounts[1];
+
+    await expect(() =>
+      multisender.disperseEther(recipients, amounts, { value: total })
+    ).to.changeEtherBalances([addr1, addr2], [amounts[0], amounts[1]]);
+  });
+});

--- a/tsconfig.hardhat.json
+++ b/tsconfig.hardhat.json
@@ -5,6 +5,11 @@
     "allowJs": true,
     "target": "es2020"
   },
-  "include": ["./scripts", "./hardhat.config.ts", "./contracts/**/*"],
+  "include": [
+    "./scripts",
+    "./hardhat.config.ts",
+    "./contracts/**/*",
+    "./test/**/*"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add `npm run test` script
- include `test` folder in `tsconfig.hardhat.json`
- add an example Hardhat test for `Multisender`

## Testing
- `npm run test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_6842ad5909048326806863a4d7284947