### PR TITLE
Implement UI components and theming

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,16 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500;600;700&display=swap');
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --accent: #005bc4;
+  --success: #2e7d32;
+  --error: #e53935;
+}
+
+html.dark {
+  --background: #121212;
+  --foreground: #ffffff;
 }
 
 html,
@@ -12,7 +22,7 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Roboto Mono', monospace;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -55,25 +65,23 @@ section {
 
 button {
   padding: 10px 15px;
-  background-color: white;
-  color: black;
-  border: 2px solid black;
+  background-color: var(--accent);
+  color: #fff;
+  border: none;
   border-radius: 6px;
   font-size: 16px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.3s ease;
-  margin: 15px; /* Space between buttons */
+  transition: background-color 0.3s ease;
+  margin: 15px;
 }
 
 button:hover {
-  background-color: black;
-    color: white;
+  background-color: #004a9e;
 }
 
 button:active {
-  background-color: #333; /* Dark gray on click */
-    color: white;
+  background-color: #003c80;
 }
 
 h1 {
@@ -88,16 +96,16 @@ pre {
 
 
 .link-button {
-  background-color: black;
-  color: white;
+  background-color: var(--accent);
+  color: #fff;
   padding: 5px 10px;
   text-decoration: none;
   border-radius: 5px;
 }
 
 .link-button:hover {
-  background-color: #333;  /* Darken the background on hover */
-  color: white;           /* Maintain text color on hover */
+  background-color: #004a9e;
+  color: #fff;
 }
 
 .advice {
@@ -122,4 +130,45 @@ pre {
   padding: 5px;
   border: 1px solid #ccc;
   border-radius: 4px;
+}
+
+.toast {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  padding: 10px 15px;
+  border-radius: 6px;
+  color: #fff;
+  animation: fadein 0.3s;
+}
+
+.toast.success {
+  background-color: var(--success);
+}
+
+.toast.error {
+  background-color: var(--error);
+}
+
+@keyframes fadein {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.spinner {
+  border: 2px solid #f3f3f3;
+  border-top: 2px solid var(--accent);
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.theme-toggle {
+  margin-bottom: 10px;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { ConnectButton } from "@/components/ConnectButton";
 import { InfoList } from "@/components/InfoList";
 import { ActionButtonList } from "@/components/ActionButtonList";
 import { MultiSenderForm } from "@/components/MultiSenderForm";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import Image from 'next/image';
 
 export default function Home() {
@@ -10,6 +11,7 @@ export default function Home() {
     <div className="pages">
       <Image src="/reown.svg" alt="Reown" width={150} height={150} priority />
       <h1>AppKit Core Next.js App Router Example</h1>
+      <ThemeToggle />
 
       <section>
         <h2>Connect Wallet</h2>

--- a/src/components/ActionButtonList.tsx
+++ b/src/components/ActionButtonList.tsx
@@ -19,9 +19,13 @@ export const ActionButtonList = () => {
         }) as { signature: string }
         
         console.log("result", result);
-      } catch (error: any) {
-        console.log("error", error);
-        throw new Error(error);
+      } catch (error: unknown) {
+        console.log('error', error)
+        if (error instanceof Error) {
+          throw new Error(error.message)
+        } else {
+          throw new Error('Unknown error')
+        }
       }
     }
     

--- a/src/components/InfoList.tsx
+++ b/src/components/InfoList.tsx
@@ -12,8 +12,7 @@ import { useClientMounted } from "@/hooks/useClientMount";
 export const InfoList = () => {
   const kitTheme = useAppKitTheme();
   const state = useAppKitState();
-  const { address, caipAddress, isConnected, embeddedWalletInfo } =
-    useAppKitAccount();
+  const { address, isConnected, embeddedWalletInfo } = useAppKitAccount();
   const events = useAppKitEvents();
   const walletInfo = useWalletInfo();
   const mounted = useClientMounted();

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export const Spinner = () => (
+  <div className="spinner" aria-label="Loading" />
+)

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export const ThemeToggle = () => {
+  const [dark, setDark] = useState(false)
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem('theme')
+    if (stored === 'dark') {
+      setDark(true)
+      document.documentElement.classList.add('dark')
+    }
+  }, [])
+
+  const toggleTheme = () => {
+    const nextDark = !dark
+    setDark(nextDark)
+    if (nextDark) {
+      document.documentElement.classList.add('dark')
+      window.localStorage.setItem('theme', 'dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+      window.localStorage.setItem('theme', 'light')
+    }
+  }
+
+  return (
+    <button onClick={toggleTheme} className="theme-toggle">
+      {dark ? 'Light Mode' : 'Dark Mode'}
+    </button>
+  )
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { useEffect } from 'react'
+
+export type ToastType = 'success' | 'error'
+
+interface ToastProps {
+  message: string | null
+  type: ToastType
+  onClose: () => void
+}
+
+export const Toast = ({ message, type, onClose }: ToastProps) => {
+  useEffect(() => {
+    if (!message) return
+    const timer = setTimeout(onClose, 3000)
+    return () => clearTimeout(timer)
+  }, [message, onClose])
+
+  if (!message) return null
+
+  return (
+    <div className={`toast ${type}`}>{message}</div>
+  )
+}


### PR DESCRIPTION
## Summary
- remove brainstorm doc
- add theme toggle component and global dark mode styles
- style buttons, links and fonts with accent color
- show toast messages and a spinner in the multi-sender form
- clean up unused vars and any types in components
- use Roboto Mono font everywhere

## Testing
- `npm run lint`
- `npx hardhat compile` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_6842ccd40e788326bd736c46ce3bbc0a