### PR TITLE
Fix undefined wallet provider error

### DIFF
--- a/src/components/MultiSenderForm.tsx
+++ b/src/components/MultiSenderForm.tsx
@@ -75,7 +75,7 @@ export const MultiSenderForm = () => {
   }, [entries, selectedToken])
 
   useEffect(() => {
-    if (!address) return
+    if (!address || !walletProvider) return
     const fetchBalances = async () => {
       const result: Record<string, bigint> = {}
       for (const t of tokenList) {
@@ -109,6 +109,12 @@ export const MultiSenderForm = () => {
     setLoading(true)
     setStatus(null)
     setError(null)
+
+    if (!walletProvider) {
+      setError('Wallet provider not available')
+      setLoading(false)
+      return
+    }
 
     if (!multisenderAddress) {
       setError('Multisender address is not configured')


### PR DESCRIPTION
## Summary
- prevent multi sender fetchBalances from running when wallet provider is missing
- guard handleSubmit to ensure walletProvider is defined before requesting

## Testing
- `npm run lint`
- `npx hardhat compile` *(fails: couldn't download compiler version due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6843b12e0e948326bf543eb86564eced