### PR TITLE
Add GitHub repo link in UI

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,6 +39,17 @@ export default function Home() {
         <h2>Debug Info</h2>
         <InfoList />
       </section>
+
+      <div className="advice">
+        <a
+          href="https://github.com/kkpsiren/senddottoken"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="link-button"
+        >
+          GitHub Repo
+        </a>
+      </div>
     </div>
   );
 }

--- a/src/components/MultiSenderForm.tsx
+++ b/src/components/MultiSenderForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { encodeFunctionData, parseUnits, type Address } from "viem";
 import { useAppKitAccount } from "@reown/appkit/react-core";
 import { multisenderAddress } from "@/config";
@@ -72,7 +72,6 @@ export const MultiSenderForm = () => {
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const MAX_RETRIES = 15;
 
   // Token selection
   const selectedToken = tokenList.find((t) => t.symbol === selectedSymbol)!;


### PR DESCRIPTION
## Summary
- expose GitHub repo via link on main page
- remove unused imports/variables to fix lint

## Testing
- `npm run lint`
- `npx hardhat compile` *(fails: couldn't download compiler)*
- `npm run test` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_6843b7bf854083268fdcb48a514ef0b0