### PR TITLE
Enable lens handle resolution

### DIFF
--- a/src/utils/lensAccounts.ts
+++ b/src/utils/lensAccounts.ts
@@ -1,5 +1,5 @@
 import { PublicClient, testnet, evmAddress } from "@lens-protocol/client";
-import { fetchAccountsBulk } from "@lens-protocol/client/actions";
+import { fetchAccountsBulk, fetchAccount } from "@lens-protocol/client/actions";
 
 const client = PublicClient.create({
   environment: testnet,
@@ -11,6 +11,9 @@ export interface LensAccountInfo {
   username: string | null;
   picture: string | null;
 }
+
+export const LENS_NAMESPACE =
+  "0xFBEdC5C278cc01A843D161d5469202Fe4EDC99E4";
 
 export async function mapAddressesToAccounts(addresses: string[]): Promise<LensAccountInfo[]> {
   const result = await fetchAccountsBulk(client, {
@@ -28,4 +31,27 @@ export async function mapAddressesToAccounts(addresses: string[]): Promise<LensA
       picture: account.metadata?.picture ?? null,
     } as LensAccountInfo;
   });
+}
+
+export async function resolveRecipient(recipient: string): Promise<string> {
+  if (/^0x[a-fA-F0-9]{40}$/.test(recipient)) {
+    return recipient;
+  }
+
+  const result = await fetchAccount(client, {
+    username: {
+      localName: recipient,
+      namespace: evmAddress(LENS_NAMESPACE),
+    },
+  });
+
+  if (result.isErr()) {
+    throw result.error;
+  }
+
+  if (!result.value) {
+    throw new Error("Username not found");
+  }
+
+  return result.value.address;
 }


### PR DESCRIPTION
## Summary
- map usernames to addresses with a new `resolveRecipient` helper
- import `resolveRecipient` in `MultiSenderForm`
- resolve lens handle strings before sending multisend tx

## Testing
- `npm run lint`
- `npx hardhat compile` *(fails: couldn't download compiler)*

------
https://chatgpt.com/codex/tasks/task_e_6843b8529f448326b08582efbe7d759c